### PR TITLE
Improve settings page

### DIFF
--- a/src/Gui/SettingsDialog.h
+++ b/src/Gui/SettingsDialog.h
@@ -142,7 +142,8 @@ protected:
     virtual void resizeEvent(QResizeEvent *event);
 
 private:
-    enum { TCP, SSL, PROCESS };
+    enum { NETWORK, PROCESS };
+    enum Encryption { NONE, STARTTLS, SSL };
     quint16 m_imapPort;
     bool m_imapStartTls;
 
@@ -150,6 +151,7 @@ private slots:
     void updateWidgets();
     void maybeShowPasswordWarning();
     void maybeShowPortWarning();
+    void changePort();
 
 private:
     ImapPage(const ImapPage &); // don't implement

--- a/src/Gui/SettingsImapPage.ui
+++ b/src/Gui/SettingsImapPage.ui
@@ -42,6 +42,16 @@ p, li { white-space: pre-wrap; }
      </widget>
     </item>
     <item row="1" column="0">
+     <widget class="QLabel" name="label">
+      <property name="text">
+       <string>Encryption</string>
+      </property>
+     </widget>
+    </item>
+    <item row="1" column="1">
+     <widget class="QComboBox" name="encryption"/>
+    </item>
+    <item row="2" column="0">
      <widget class="QLabel" name="imapHostLabel">
       <property name="text">
        <string>Ser&amp;ver</string>
@@ -51,7 +61,20 @@ p, li { white-space: pre-wrap; }
       </property>
      </widget>
     </item>
-    <item row="2" column="0">
+    <item row="2" column="1">
+     <widget class="LineEdit" name="imapHost">
+      <property name="toolTip">
+       <string>Hostname of the IMAP server</string>
+      </property>
+      <property name="whatsThis">
+       <string>This is the name of the IMAP server that Trojitá should connect to.</string>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+     </widget>
+    </item>
+    <item row="3" column="0">
      <widget class="QLabel" name="imapPortLabel">
       <property name="text">
        <string>&amp;Port</string>
@@ -61,13 +84,23 @@ p, li { white-space: pre-wrap; }
       </property>
      </widget>
     </item>
-    <item row="4" column="0">
-     <widget class="QLabel" name="startTlsLabel">
-      <property name="text">
-       <string>Perform S&amp;TARTTLS</string>
+    <item row="3" column="1">
+     <widget class="LineEdit" name="imapPort">
+      <property name="toolTip">
+       <string>Port number of the IMAP server</string>
       </property>
-      <property name="buddy">
-       <cstring>startTls</cstring>
+      <property name="text">
+       <string/>
+      </property>
+     </widget>
+    </item>
+    <item row="4" column="0" colspan="2">
+     <widget class="QLabel" name="portWarning">
+      <property name="text">
+       <string>This port number looks suspicious. The usual numbers for IMAP are 143 (with the TCP connection method or with STARTTLS) and 993 (when using SSL).</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
       </property>
      </widget>
     </item>
@@ -81,78 +114,6 @@ p, li { white-space: pre-wrap; }
       </property>
      </widget>
     </item>
-    <item row="6" column="0">
-     <widget class="QLabel" name="imapPassLabel">
-      <property name="text">
-       <string>Pass&amp;word</string>
-      </property>
-      <property name="buddy">
-       <cstring>imapPass</cstring>
-      </property>
-     </widget>
-    </item>
-    <item row="8" column="0">
-     <widget class="QLabel" name="processPathLabel">
-      <property name="text">
-       <string>Path to Server &amp;Binary</string>
-      </property>
-      <property name="buddy">
-       <cstring>processPath</cstring>
-      </property>
-     </widget>
-    </item>
-    <item row="9" column="0">
-     <widget class="QLabel" name="startOfflineLabel">
-      <property name="text">
-       <string>Start in O&amp;ffline Mode</string>
-      </property>
-      <property name="buddy">
-       <cstring>startOffline</cstring>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
-     <widget class="LineEdit" name="imapHost">
-      <property name="toolTip">
-       <string>Hostname of the IMAP server</string>
-      </property>
-      <property name="whatsThis">
-       <string>This is the name of the IMAP server that Trojitá should connect to.</string>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="1">
-     <widget class="LineEdit" name="imapPort">
-      <property name="toolTip">
-       <string>Port number of the IMAP server</string>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="1">
-     <widget class="QCheckBox" name="startTls">
-      <property name="toolTip">
-       <string>Transparently upgrade the plaintext connection to an encrypted one</string>
-      </property>
-      <property name="whatsThis">
-       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'DejaVu Sans'; font-size:8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Choose this option to require that Trojitá performs a STARTTLS operation on the connection to the remote IMAP server. This means that it will make sure that while the connection starts in an unencrypted mode, it will get &amp;quot;upgraded&amp;quot; to encryption on the fly.&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;This option is enabled only for plain &lt;span style=&quot; font-style:italic;&quot;&gt;TCP&lt;/span&gt; method of connecting to the IMAP server, as the &lt;span style=&quot; font-style:italic;&quot;&gt;Local process&lt;/span&gt; doesn't support it and the &lt;span style=&quot; font-style:italic;&quot;&gt;SSL&lt;/span&gt; one is already encrypted.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-      </property>
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
-    </item>
     <item row="5" column="1">
      <widget class="LineEdit" name="imapUser">
       <property name="toolTip">
@@ -163,6 +124,16 @@ p, li { white-space: pre-wrap; }
       </property>
       <property name="text">
        <string/>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="0">
+     <widget class="QLabel" name="imapPassLabel">
+      <property name="text">
+       <string>Pass&amp;word</string>
+      </property>
+      <property name="buddy">
+       <cstring>imapPass</cstring>
       </property>
      </widget>
     </item>
@@ -190,6 +161,26 @@ p, li { white-space: pre-wrap; }
       </property>
      </widget>
     </item>
+    <item row="7" column="0" colspan="2">
+     <widget class="QLabel" name="passwordWarning">
+      <property name="text">
+       <string>The password will be stored in plaintext. Leave it blank for Trojitá to prompt when needed.</string>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item row="8" column="0">
+     <widget class="QLabel" name="processPathLabel">
+      <property name="text">
+       <string>Path to Server &amp;Binary</string>
+      </property>
+      <property name="buddy">
+       <cstring>processPath</cstring>
+      </property>
+     </widget>
+    </item>
     <item row="8" column="1">
      <widget class="LineEdit" name="processPath">
       <property name="whatsThis">
@@ -206,6 +197,16 @@ p, li { white-space: pre-wrap; }
       </property>
      </widget>
     </item>
+    <item row="9" column="0">
+     <widget class="QLabel" name="startOfflineLabel">
+      <property name="text">
+       <string>Start in O&amp;ffline Mode</string>
+      </property>
+      <property name="buddy">
+       <cstring>startOffline</cstring>
+      </property>
+     </widget>
+    </item>
     <item row="9" column="1">
      <widget class="QCheckBox" name="startOffline">
       <property name="toolTip">
@@ -219,13 +220,13 @@ p, li { white-space: pre-wrap; }
       </property>
      </widget>
     </item>
-    <item row="7" column="0" colspan="2">
-     <widget class="QLabel" name="passwordWarning">
+    <item row="10" column="0">
+     <widget class="QLabel" name="imapEnableIdLabel">
       <property name="text">
-       <string>This password will be saved on disk in clear text. If you do not enter password here, Trojitá will prompt for one when needed.</string>
+       <string>Reveal I'm using Trojitá</string>
       </property>
-      <property name="wordWrap">
-       <bool>true</bool>
+      <property name="buddy">
+       <cstring>imapEnableId</cstring>
       </property>
      </widget>
     </item>
@@ -245,16 +246,6 @@ p, li { white-space: pre-wrap; }
       </property>
      </widget>
     </item>
-    <item row="10" column="0">
-     <widget class="QLabel" name="imapEnableIdLabel">
-      <property name="text">
-       <string>Ask for IMAP &amp;ID</string>
-      </property>
-      <property name="buddy">
-       <cstring>imapEnableId</cstring>
-      </property>
-     </widget>
-    </item>
     <item row="11" column="0">
      <widget class="QLabel" name="imapCapabilitiesBlacklistLabel">
       <property name="text">
@@ -267,16 +258,6 @@ p, li { white-space: pre-wrap; }
     </item>
     <item row="11" column="1">
      <widget class="LineEdit" name="imapCapabilitiesBlacklist"/>
-    </item>
-    <item row="3" column="0" colspan="2">
-     <widget class="QLabel" name="portWarning">
-      <property name="text">
-       <string>This port number looks suspicious. The usual numbers for IMAP are 143 (with the TCP connection method or with STARTTLS) and 993 (when using SSL).</string>
-      </property>
-      <property name="wordWrap">
-       <bool>true</bool>
-      </property>
-     </widget>
     </item>
    </layout>
   </widget>


### PR DESCRIPTION
- Changes the IMAP method to a QTabWidget so only relevant fields appear
- Changes wording of the port warnings to be clear about the normal port
- Changes SMTP to hide fields that are not relevant.
- Changes wording of the offline / cache page
