### PR TITLE
Fixed build error

### DIFF
--- a/src/Ubuntu/main.cpp
+++ b/src/Ubuntu/main.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[])
     QString qmlfile;
     QString appPath = QGuiApplication::applicationDirPath();
     if (parser.isSet(qmlFileOption)) {
-        qmlfile = QString::toUtf8(appPath + parser.value(qmlFileOption));
+        qmlfile = appPath + parser.value(qmlFileOption);
     } else {
         qmlfile = "qml/trojita/main.qml";
     }


### PR DESCRIPTION
Excerpt from the make output before the change:

`Building CXX object CMakeFiles/trojita.dir/src/Ubuntu/main.cpp.o
/home/nikwen/Programmieren/Ubuntu/trojita/src/Ubuntu/main.cpp: In function ‘int main(int, char**)’:
/home/nikwen/Programmieren/Ubuntu/trojita/src/Ubuntu/main.cpp:92:72: error: no matching function for call to ‘QString::toUtf8(const QString)’
         qmlfile = QString::toUtf8(appPath + parser.value(qmlFileOption));
                                                                        ^
/home/nikwen/Programmieren/Ubuntu/trojita/src/Ubuntu/main.cpp:92:72: note: candidate is:
In file included from /usr/include/qt5/QtCore/qobject.h:49:0,
                 from /usr/include/qt5/QtCore/qiodevice.h:47,
                 from /usr/include/qt5/QtCore/qdatastream.h:46,
                 from /usr/include/qt5/QtCore/qstringlist.h:46,
                 from /usr/include/qt5/QtCore/qcommandlineoption.h:45,
                 from /usr/include/qt5/QtCore/QCommandLineOption:1,
                 from /home/nikwen/Programmieren/Ubuntu/trojita/src/Ubuntu/main.cpp:22:
/usr/include/qt5/QtCore/qstring.h:464:16: note: QByteArray QString::toUtf8() const
     QByteArray toUtf8() const Q_REQUIRED_RESULT;
                ^
/usr/include/qt5/QtCore/qstring.h:464:16: note:   candidate expects 0 arguments, 1 provided
make[2]: *** [CMakeFiles/trojita.dir/src/Ubuntu/main.cpp.o] Fehler 1
make[1]: *** [CMakeFiles/trojita.dir/all] Fehler 2
make[1]: *** Warte auf noch nicht beendete Prozesse...
Linking CXX static library libtest_LibMailboxSync.a
[ 75%] Built target test_LibMailboxSync
make: *** [all] Fehler 2`

(Used cmake options: -DWITH_UBUNTU=ON)
