### PR TITLE
- Add imap-idle-renewal time in settings (bug 337846)

### DIFF
--- a/src/Common/SettingsNames.cpp
+++ b/src/Common/SettingsNames.cpp
@@ -95,5 +95,6 @@ const QString SettingsNames::appLoadHomepage = QLatin1String("app.updates.checkE
 const QString SettingsNames::knownEmailsKey = QLatin1String("addressBook/knownEmails");
 const QString SettingsNames::addressbookPlugin = QLatin1String("plugin/addressbook");
 const QString SettingsNames::passwordPlugin = QLatin1String("plugin/password");
+const QString SettingsNames::imapIdleRenewal = QLatin1String("imapIdleRenewal");
 
 }

--- a/src/Common/SettingsNames.h
+++ b/src/Common/SettingsNames.h
@@ -52,6 +52,7 @@ struct SettingsNames {
     static const QString guiShowSystray, guiOnSystrayClose, guiStartMinimized;
     static const QString knownEmailsKey;
     static const QString addressbookPlugin, passwordPlugin;
+    static const QString imapIdleRenewal;
 };
 
 }

--- a/src/Gui/SettingsDialog.cpp
+++ b/src/Gui/SettingsDialog.cpp
@@ -475,6 +475,7 @@ ImapPage::ImapPage(SettingsDialog *parent, QSettings &s): QScrollArea(parent), U
     imapCapabilitiesBlacklist->setText(s.value(SettingsNames::imapBlacklistedCapabilities).toStringList().join(QLatin1String(" ")));
     imapUseSystemProxy->setChecked(s.value(SettingsNames::imapUseSystemProxy, true).toBool());
     imapNeedsNetwork->setChecked(s.value(SettingsNames::imapNeedsNetwork, true).toBool());
+    imapIdleRenewal->setValue(s.value(SettingsNames::imapIdleRenewal, QVariant(29)).toInt());
 
     m_imapPort = s.value(SettingsNames::imapPortKey, QString::number(defaultImapPort)).value<quint16>();
 
@@ -607,6 +608,7 @@ void ImapPage::save(QSettings &s)
     s.setValue(SettingsNames::imapEnableId, imapEnableId->isChecked());
     s.setValue(SettingsNames::imapBlacklistedCapabilities, imapCapabilitiesBlacklist->text().split(QLatin1String(" ")));
     s.setValue(SettingsNames::imapNeedsNetwork, imapNeedsNetwork->isChecked());
+    s.setValue(SettingsNames::imapIdleRenewal, imapIdleRenewal->value());
 
     m_pwWatcher->setPassword(imapPass->text());
 }

--- a/src/Gui/SettingsImapPage.ui
+++ b/src/Gui/SettingsImapPage.ui
@@ -317,6 +317,32 @@ p, li { white-space: pre-wrap; }
       </property>
      </widget>
     </item>
+    <item row="15" column="0">
+     <widget class="QLabel" name="imapIdleRenewalLabel">
+      <property name="text">
+       <string>IMAP idle renewal</string>
+      </property>
+     </widget>
+    </item>
+    <item row="15" column="1">
+     <widget class="QSpinBox" name="imapIdleRenewal">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
+        <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="toolTip">
+       <string>Timeout of IMAP idle in minutes</string>
+      </property>
+      <property name="minimum">
+       <number>1</number>
+      </property>
+      <property name="maximum">
+       <number>60</number>
+      </property>
+     </widget>
+    </item>
    </layout>
   </widget>
  </widget>

--- a/src/Imap/Model/ImapAccess.cpp
+++ b/src/Imap/Model/ImapAccess.cpp
@@ -320,6 +320,7 @@ void ImapAccess::doConnect()
     m_imapModel->setObjectName(QString::fromUtf8("imapModel-%1").arg(m_accountName));
     m_imapModel->setCapabilitiesBlacklist(m_settings->value(Common::SettingsNames::imapBlacklistedCapabilities).toStringList());
     m_imapModel->setProperty("trojita-imap-enable-id", m_settings->value(Common::SettingsNames::imapEnableId, true).toBool());
+    m_imapModel->setProperty("trojita-imap-idle-renewal", m_settings->value(Common::SettingsNames::imapIdleRenewal).toUInt() * 60 * 1000);
     connect(m_imapModel, SIGNAL(alertReceived(QString)), this, SLOT(alertReceived(QString)));
     connect(m_imapModel, SIGNAL(imapError(QString)), this, SLOT(imapError(QString)));
     connect(m_imapModel, SIGNAL(networkError(QString)), this, SLOT(networkError(QString)));


### PR DESCRIPTION
Adjust the time of imap idle renewal to avoid switching to offline mode (eg with a free.fr imap account)
https://bugs.kde.org/show_bug.cgi?id=337846
