### PR TITLE
harmattan launcher: add LD_LIBRARY_PATH

### DIFF
--- a/src/Harmattan/trojita-tp_harmattan.desktop
+++ b/src/Harmattan/trojita-tp_harmattan.desktop
@@ -37,7 +37,7 @@ Name[ug]=Trojitá
 Name[uk]=Trojitá
 Name[x-test]=xxTrojitáxx
 Name[zh_TW]=Trojitá
-Exec=/usr/bin/single-instance /opt/trojita-tp/bin/trojita-tp
+Exec=/bin/sh -c "LD_LIBRARY_PATH=/opt/trojita-tp/lib /usr/bin/single-instance /opt/trojita-tp/bin/trojita-tp"
 Icon=/usr/share/icons/hicolor/80x80/apps/trojita-tp80.png
 X-Window-Icon=
 X-HildonDesk-ShowInToolbar=true


### PR DESCRIPTION
this works for me on openmode. i never know what will work for someone else, but i DO know that it wont launch without the lib path being set somehow.
